### PR TITLE
Fix for base model class

### DIFF
--- a/app/lib/FFMVC/Models/Base.php
+++ b/app/lib/FFMVC/Models/Base.php
@@ -2,6 +2,8 @@
 
 namespace FFMVC\Models;
 
+use FFMVC\Helpers as Helpers;
+
 /**
  * Base Model Class.
  *


### PR DESCRIPTION
Base model class missing namespace alias causing an error